### PR TITLE
:tada: 기존 게시글 Entity 수정 및 지역,분류,찜,스택 등 Entity 등록

### DIFF
--- a/src/main/java/backend/whereIsMyTeam/domain/Area.java
+++ b/src/main/java/backend/whereIsMyTeam/domain/Area.java
@@ -1,0 +1,31 @@
+package backend.whereIsMyTeam.domain;
+
+//지역 테이블
+
+import backend.whereIsMyTeam.config.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Table(name = "AREAS")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Area extends BaseTimeEntity {
+
+    //값 17개 중 1택
+    //기타/제주/순천/원주/청주/천안/세종/대전/전주/광주/울산/부산/대구/인천/수원/서울/수도권/전국
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "area_idx",nullable = false, unique = true)
+    private Long areaIdx;
+
+    @Column(name = "area_name", nullable = false)
+    private String name;
+
+
+}

--- a/src/main/java/backend/whereIsMyTeam/domain/Board.java
+++ b/src/main/java/backend/whereIsMyTeam/domain/Board.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -20,12 +22,18 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Board extends BaseTimeEntity {
 
+    /**
+     * [필드에 들어가야 하는 것들]
+     *   : 제목,글 내용, 조회수,분류(카테고리), 모집인원, 상태(모집중,모집완료,임시저장[게시 안된 상태],삭제상태)
+     * [테이블 생성 할 것]
+     *  : 지역,스택,스택_게시글, 모집파트_게시글,즐겨찾기(찜), 모집파트(추가가능 하도록=태그기능?)
+     *
+     **/
 
-    //필드에 들어가야 하는 것들:
-    // 제목,글 내용, 조회수,분류(카테고리), 모집인원, 상태(모집중,모집완료,임시저장[게시 안된 상태],삭제상태)
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="board_Idx",nullable = false, unique = true)
+    @Column(name="board_idx",nullable = false, unique = true)
     private Long boardIdx;
 
     //제목
@@ -36,40 +44,60 @@ public class Board extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-    //작성자(닉네임) _User 객체에서 참조
-//    @Column
-//    private String nickname;
-
-    //게시글 조회 수
+    /**
+     *  필드: 게시글 조회 수 => ['인기순' 나열 기준]
+     *  기능 요구사항: 클릭 시 중복되지 않도록 방법이 필요
+     *  Q1.의문점) 좋아요(찜) => 회원 즐겨찾기에 추가되는 기능만 가짐.
+     *  Q2. 인기순의 기준을 찜의 갯수로 측정해야 하는 것이 아닌가?
+    **/
     @Column
     private Long cnt;
 
-    //글 상태 4가지 중 1개 택 _BoardStatus
-    @Column(nullable = false, length = 10)
+    //게시글 상태 4가지 중 1개 택
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private BoardStatus status;
 
 
-    //회의방식 (온/온오프/오프라인)
+    //회의방식 (온/온오프/오프라인) 중 1택
+    @Enumerated(value = EnumType.STRING)
+    @Column()
+    private MeetingStatus meetingStatus;
+
+    //분류(카테고리)
+    //다대일 단방향
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_idx")
+    private Category category;
 
 
+    // 모집인원
+    private int recruitment;
 
     //댓글
     @OneToMany(mappedBy = "board", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
-    private List<Comment> comments;
+    private List<Comment> comments = new ArrayList<>();
 
 
+    //다대일 양방향 게시글(n): 유저(1)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_idx")
+    @OnDelete(action = OnDeleteAction.CASCADE) //작성자가 탈퇴시, 글도 삭제해주자
+    private User writer;
 
-
-
+    //다대일 일대다 양방향
+    @OneToMany(mappedBy = "boards")
+    private List<TechStackBoard> techstacks = new ArrayList<>();
 
 
     //게시글 작성 Builder
     @Builder
-    public Board(String title, BoardStatus stauts, String content) {
+    public Board(String title, String content, User writer, Category category) {
         this.title=title;
-        this.status=status;
+        this.category = category;
+        //this.status=status;
         this.content = content;
+        this.writer = writer;
     }
 
 

--- a/src/main/java/backend/whereIsMyTeam/domain/Category.java
+++ b/src/main/java/backend/whereIsMyTeam/domain/Category.java
@@ -1,0 +1,29 @@
+package backend.whereIsMyTeam.domain;
+
+import backend.whereIsMyTeam.config.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@DynamicInsert
+@Table(name = "CATEGORYS")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_idx",nullable = false, unique = true)
+    private Long categoryIdx;
+
+    @Column(name = "category_name" ,nullable = false)
+    private String categoryName;
+
+
+
+
+}

--- a/src/main/java/backend/whereIsMyTeam/domain/MeetingStatus.java
+++ b/src/main/java/backend/whereIsMyTeam/domain/MeetingStatus.java
@@ -1,0 +1,17 @@
+package backend.whereIsMyTeam.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MeetingStatus {
+
+    //회의방식(온라인, 오프라인, 온/오프)
+    ONLINED(0,"온라인"),
+    OFFLINED(1, "오프라인"),
+    BLENDED(2,"온/오프");
+
+    private Integer code;
+    private String status;
+}

--- a/src/main/java/backend/whereIsMyTeam/domain/PostLike.java
+++ b/src/main/java/backend/whereIsMyTeam/domain/PostLike.java
@@ -1,0 +1,43 @@
+package backend.whereIsMyTeam.domain;
+
+import backend.whereIsMyTeam.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "POSTLIKES") //찜(즐겨찾기)
+public class PostLike {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "postLike_idx")
+    private Long likeIdx;
+
+    /**
+     * 좋아요(N) -  유저(1)
+     * 다대일 단방향
+     **/
+    @ManyToOne
+    @JoinColumn(name = "user_idx")//FK
+    private User user;
+
+    /**
+     * 좋아요(N) - 게시글(1)
+     *  다대일 단방향
+     **/
+    @ManyToOne
+    @JoinColumn(name = "board_idx")
+    private Board board;
+
+    @Builder
+    public PostLike(User user, Board board){
+        this.user = user;
+        this.board = board;
+    }
+
+
+}

--- a/src/main/java/backend/whereIsMyTeam/domain/TechStack.java
+++ b/src/main/java/backend/whereIsMyTeam/domain/TechStack.java
@@ -1,0 +1,21 @@
+package backend.whereIsMyTeam.domain;
+
+import backend.whereIsMyTeam.config.BaseTimeEntity;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TechStack extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "stack_idx",nullable = false, unique = true)
+    private Long stackIdx;
+
+    @Column(nullable = false)
+    private String stackName;
+
+    @OneToMany(mappedBy = "techStack")
+    private List<TechStackBoard> boards = new ArrayList<>();
+}

--- a/src/main/java/backend/whereIsMyTeam/domain/TechStackBoard.java
+++ b/src/main/java/backend/whereIsMyTeam/domain/TechStackBoard.java
@@ -1,0 +1,34 @@
+package backend.whereIsMyTeam.domain;
+
+import backend.whereIsMyTeam.config.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+
+@Entity
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TechStackBoard extends BaseTimeEntity {
+
+    //조인테이블
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "stackBoard_idx",nullable = false, unique = true)
+    private Long stackBoardIdx;
+
+
+
+    @ManyToOne
+    @JoinColumn(name = "board_idx")
+    private Board board;
+
+    //오류발생 매핑 문제?
+//    @ManyToOne
+//    @JoinColumn(name = "stack_idx")
+//    private TechStack techStack;
+}


### PR DESCRIPTION
</b>*생성해 놓은 엔티티</b>
게시판(Board), 게시판 상태[enum](BoardStatus),분류(Category), 댓글(Comment), 미팅상태[enum] (MeetingStatus),
(좋아요 =즐겨찾기?]( PostLike) , 스택(TechStatkc), 스택_게시글 (TechStack)



<b>1.기본적인 매핑관계를 구현</b>
-> 관계가 애매하거나 List로 끌어와도 될지 모르는 애들은 기본적으로 외래관계 방향을 단방향으로 함.(추후 필요에 따라 양방향 변환 가능)
 -> 필요한 필드명만 선언만 함


<b>2. '분류' 테이블 -> Category 클래스로 선언 및 결정</b>

<b>3.  찜(즐겨찾기) 테이블 -> 다대일 일대다 단방향으로 구현</b>

<b>4. 스택 - 스택_게시글 - 게시글 [생성함]</b>
-> 조인테이블 오류발생

</b>5. 분류- 분류_게시글 - 게시글 [구현 x] </b>